### PR TITLE
support for compact-mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.gatanaso</groupId>
     <artifactId>multiselect-combo-box-flow</artifactId>
-    <version>0.0.8</version>
+    <version>0.1.0-SNAPSHOT</version>
     <name>Multiselect Combo Box</name>
     <description>Integration of multiselect-combo-box for Vaadin platform</description>
 
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.gatanaso</groupId>
             <artifactId>multiselect-combo-box</artifactId>
-            <version>0.1.1</version>
+            <version>0.2.0</version>
         </dependency>
         <!-- override vaadin-bom defined version -->
         <dependency>

--- a/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
+++ b/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
@@ -147,6 +147,25 @@ public class MultiselectComboBox<T>
     }
 
     /**
+     * Gets the 'compact-mode' property value of the multiselect-combo-box.
+     *
+     * @return true if the component is in 'compact-mode', false otherwise.
+     */
+    public boolean isCompactMode() {
+        return getElement().getProperty("compactMode", false);
+    }
+
+    /**
+     * Sets the 'compact-mode' property value of the multiselect-combo-box.
+     *
+     * @param compactMode
+     *            the boolean value to set
+     */
+    public void setCompactMode(boolean compactMode) {
+        getElement().setProperty("compactMode", compactMode);
+    }
+
+    /**
      * Gets the validity of the multiselect-combo-box.
      *
      * @return true if the component is invalid, false otherwise.

--- a/src/test/java/org/vaadin/gatanaso/MultiselectComboBoxTest.java
+++ b/src/test/java/org/vaadin/gatanaso/MultiselectComboBoxTest.java
@@ -116,6 +116,21 @@ public class MultiselectComboBoxTest {
     }
 
     @Test
+    public void shouldSetCompactMode() {
+        // given
+        MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox<>();
+
+        Assert.assertFalse(multiselectComboBox.isCompactMode());
+
+        // when
+        multiselectComboBox.setCompactMode(true);
+
+        // then
+        assertThat(multiselectComboBox.isCompactMode(), is(true));
+        assertThat(multiselectComboBox.getElement().getProperty("compactMode"), is("true"));
+    }
+
+    @Test
     public void shouldSetInvalid() {
         // given
         MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox<>();

--- a/src/test/java/org/vaadin/gatanaso/demo/DemoView.java
+++ b/src/test/java/org/vaadin/gatanaso/demo/DemoView.java
@@ -24,6 +24,7 @@ public class DemoView extends VerticalLayout {
         addObjectDemo();
         addObjectDemoWithLabelGenerator();
         addRequiredDemo();
+        addCompactModeDemo();
     }
 
     private void addTitle() {
@@ -90,6 +91,21 @@ public class DemoView extends VerticalLayout {
         multiselectComboBox.setErrorMessage("The field is mandatory");
         multiselectComboBox.setItems("Item 1", "Item 2", "Item 3", "Item 4");
         multiselectComboBox.addSelectionListener(event -> Notification.show(event.toString()));
+
+        Button getValueBtn = new Button("Get value");
+        getValueBtn.addClickListener(event -> multiselectComboBoxValueChangeHandler(multiselectComboBox));
+
+        add(buildDemoContainer(multiselectComboBox, getValueBtn));
+    }
+
+    private void addCompactModeDemo() {
+        MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox();
+        multiselectComboBox.setLabel("Multiselect combo box in compact mode");
+        multiselectComboBox.setPlaceholder("Add");
+        multiselectComboBox.setItems("Item 1", "Item 2", "Item 3", "Item 4");
+        multiselectComboBox.addSelectionListener(event -> Notification.show(event.toString()));
+
+        multiselectComboBox.setCompactMode(true);
 
         Button getValueBtn = new Button("Get value");
         getValueBtn.addClickListener(event -> multiselectComboBoxValueChangeHandler(multiselectComboBox));


### PR DESCRIPTION
This PR introduces the `compact mode` of the `multiselect-combo-box`. In this mode of operation the component displays the number of selected items (instead of individual tokens):

![compact-mode](https://user-images.githubusercontent.com/15094658/57573468-8c250780-7430-11e9-9fb8-810f3be07c89.gif)