### PR TITLE
feature/clear button visible attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the `multiselect-combo-box-flow dependency` to your `pom.xml` file:
 <dependency>
    <groupId>org.vaadin.gatanaso</groupId>
    <artifactId>multiselect-combo-box-flow</artifactId>
-   <version>2.1.0</version>
+   <version>2.2.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.gatanaso</groupId>
     <artifactId>multiselect-combo-box-flow</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <name>Multiselect Combo Box</name>
     <description>Integration of multiselect-combo-box for Vaadin platform</description>
 
@@ -114,6 +114,10 @@
                             <Vaadin-Package-Version>1</Vaadin-Package-Version>
                         </manifestEntries>
                     </archive>
+                    <!-- Generated file that shouldn't be included in add-ons -->
+                    <excludes>
+                        <exclude>META-INF/VAADIN/config/flow-build-info.json</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
 			<plugin>

--- a/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
+++ b/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
@@ -81,7 +81,7 @@ import elemental.json.JsonValue;
  * @author gatanaso
  */
 @Tag("multiselect-combo-box")
-@NpmPackage(value = "multiselect-combo-box", version = "2.0.3")
+@NpmPackage(value = "multiselect-combo-box", version = "2.1.0")
 @JsModule("multiselect-combo-box/src/multiselect-combo-box.js")
 @JavaScript("frontend://multiselectComboBoxConnector.js")
 @JsModule("./multiselectComboBoxConnector-es6.js")
@@ -419,6 +419,32 @@ public class MultiselectComboBox<T>
     public void setErrorMessage(String errorMessage) {
         getElement().setProperty("errorMessage",
                 errorMessage == null ? "" : errorMessage);
+    }
+
+    /**
+     * <p>
+     * Set to true to display the clear icon which clears the input.
+     * <p>
+     * This property is not synchronized automatically from the client side, so
+     * the returned value may not be the same as in client side.
+     * </p>
+     *
+     * @return the {@code clearButtonVisible} property from the web component
+     */
+    public boolean isClearButtonVisible() {
+        return getElement().getProperty("clearButtonVisible", false);
+    }
+
+    /**
+     * <p>
+     * Set to true to display the clear icon which clears the input.
+     * </p>
+     *
+     * @param clearButtonVisible
+     *            the boolean value to set
+     */
+    public void setClearButtonVisible(boolean clearButtonVisible) {
+        getElement().setProperty("clearButtonVisible", clearButtonVisible);
     }
 
     private void setItemValuePath(String itemValuePath) {

--- a/src/test/java/org/vaadin/gatanaso/MultiselectComboBoxTest.java
+++ b/src/test/java/org/vaadin/gatanaso/MultiselectComboBoxTest.java
@@ -202,6 +202,21 @@ public class MultiselectComboBoxTest {
     }
 
     @Test
+    public void shouldSetClearButtonVisible() {
+        // given
+        MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox<>();
+
+        Assert.assertFalse(multiselectComboBox.isClearButtonVisible());
+
+        // when
+        multiselectComboBox.setClearButtonVisible(true);
+
+        // then
+        assertThat(multiselectComboBox.isClearButtonVisible(), is(true));
+        assertThat(multiselectComboBox.getElement().getProperty("clearButtonVisible"), is("true"));
+    }
+
+    @Test
     public void shouldUpdateDataProviderAndResetValueToEmpty() {
         // given
         MultiselectComboBox<Object> multiselectComboBox = new MultiselectComboBox<>();

--- a/src/test/java/org/vaadin/gatanaso/demo/DemoView.java
+++ b/src/test/java/org/vaadin/gatanaso/demo/DemoView.java
@@ -29,6 +29,7 @@ public class DemoView extends VerticalLayout {
         addCompactModeDemo();
         addOrderedDemo();
         addLazyLoadingDemo();
+        addClearButtonVisibleDemo();
     }
 
     private void addTitle() {
@@ -160,6 +161,24 @@ public class DemoView extends VerticalLayout {
 
         multiselectComboBox.addSelectionListener(
                 event -> Notification.show(event.toString()));
+
+        Button getValueBtn = new Button("Get value");
+        getValueBtn.addClickListener(
+                event -> multiselectComboBoxValueChangeHandler(
+                        multiselectComboBox));
+
+        add(buildDemoContainer(multiselectComboBox, getValueBtn));
+    }
+
+    private void addClearButtonVisibleDemo() {
+        MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox();
+        multiselectComboBox.setLabel("Multiselect combo box with `clear-button-visible`");
+        multiselectComboBox.setPlaceholder("Add");
+        multiselectComboBox.setItems("Item 1", "Item 2", "Item 3", "Item 4");
+        multiselectComboBox.addSelectionListener(
+                event -> Notification.show(event.toString()));
+
+        multiselectComboBox.setClearButtonVisible(true);
 
         Button getValueBtn = new Button("Get value");
         getValueBtn.addClickListener(


### PR DESCRIPTION
To better align with the vaadin component defaults, the `clear-button-visible`
attribute is now also available to the `MultiselectComboBox`. With this update
the component no longer displays the clear icon by default, but instead
it needs to be specified explicitly. This change breaks the default behavior
in favor of aligning better with the current default behavior of the
`vaadin-text-field` and `vaadin-combo-box` components.