### PR TITLE
backported the `clear-button-visible` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the `multiselect-combo-box-flow dependency` to your `pom.xml` file:
 <dependency>
    <groupId>org.vaadin.gatanaso</groupId>
    <artifactId>multiselect-combo-box-flow</artifactId>
-   <version>1.0.1</version>
+   <version>1.1.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.gatanaso</groupId>
     <artifactId>multiselect-combo-box-flow</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <name>Multiselect Combo Box</name>
     <description>Integration of multiselect-combo-box for Vaadin platform</description>
 
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.gatanaso</groupId>
             <artifactId>multiselect-combo-box</artifactId>
-            <version>1.0.1</version>
+            <version>1.1.0</version>
         </dependency>
         <!-- override vaadin-bom defined version -->
         <dependency>

--- a/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
+++ b/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
@@ -1,5 +1,12 @@
 package org.vaadin.gatanaso;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import com.vaadin.flow.component.AbstractSinglePropertyField;
 import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasSize;
@@ -18,16 +25,10 @@ import com.vaadin.flow.data.selection.MultiSelect;
 import com.vaadin.flow.data.selection.MultiSelectionEvent;
 import com.vaadin.flow.data.selection.MultiSelectionListener;
 import com.vaadin.flow.shared.Registration;
+
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * A multiselection component where items are displayed in a drop-down list.
@@ -228,6 +229,32 @@ public class MultiselectComboBox<T>
     @Override
     public void setErrorMessage(String errorMessage) {
         getElement().setProperty("errorMessage", errorMessage == null ? "" : errorMessage);
+    }
+
+    /**
+     * <p>
+     * Set to true to display the clear icon which clears the input.
+     * <p>
+     * This property is not synchronized automatically from the client side, so
+     * the returned value may not be the same as in client side.
+     * </p>
+     *
+     * @return the {@code clearButtonVisible} property from the web component
+     */
+    public boolean isClearButtonVisible() {
+        return getElement().getProperty("clearButtonVisible", false);
+    }
+
+    /**
+     * <p>
+     * Set to true to display the clear icon which clears the input.
+     * </p>
+     *
+     * @param clearButtonVisible
+     *            the boolean value to set
+     */
+    public void setClearButtonVisible(boolean clearButtonVisible) {
+        getElement().setProperty("clearButtonVisible", clearButtonVisible);
     }
 
     private void setItemValuePath(String itemValuePath) {

--- a/src/test/java/org/vaadin/gatanaso/MultiselectComboBoxTest.java
+++ b/src/test/java/org/vaadin/gatanaso/MultiselectComboBoxTest.java
@@ -1,17 +1,18 @@
 package org.vaadin.gatanaso;
 
-import com.vaadin.flow.data.provider.ConfigurableFilterDataProvider;
-import com.vaadin.flow.data.provider.DataProvider;
-import com.vaadin.flow.data.provider.Query;
-import com.vaadin.flow.function.SerializablePredicate;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.data.provider.ConfigurableFilterDataProvider;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.Query;
+import com.vaadin.flow.function.SerializablePredicate;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
@@ -186,6 +187,21 @@ public class MultiselectComboBoxTest {
         assertThat(multiselectComboBox.items, hasItem("item 1"));
         assertThat(multiselectComboBox.items, hasItem("item 2"));
         assertThat(multiselectComboBox.items, hasItem("item 3"));
+    }
+
+    @Test
+    public void shouldSetClearButtonVisible() {
+        // given
+        MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox<>();
+
+        Assert.assertFalse(multiselectComboBox.isClearButtonVisible());
+
+        // when
+        multiselectComboBox.setClearButtonVisible(true);
+
+        // then
+        assertThat(multiselectComboBox.isClearButtonVisible(), is(true));
+        assertThat(multiselectComboBox.getElement().getProperty("clearButtonVisible"), is("true"));
     }
 
     private static class TestMultiselectComboBox extends MultiselectComboBox<String> {

--- a/src/test/java/org/vaadin/gatanaso/demo/DemoView.java
+++ b/src/test/java/org/vaadin/gatanaso/demo/DemoView.java
@@ -1,16 +1,17 @@
 package org.vaadin.gatanaso.demo;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.vaadin.gatanaso.MultiselectComboBox;
+
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
-import org.vaadin.gatanaso.MultiselectComboBox;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Route("")
 public class DemoView extends VerticalLayout {
@@ -26,6 +27,7 @@ public class DemoView extends VerticalLayout {
         addRequiredDemo();
         addCompactModeDemo();
         addOrderedDemo();
+        addClearButtonVisibleDemo();
     }
 
     private void addTitle() {
@@ -130,6 +132,23 @@ public class DemoView extends VerticalLayout {
         add(buildDemoContainer(multiselectComboBox, getValueBtn));
     }
 
+    private void addClearButtonVisibleDemo() {
+        MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox();
+        multiselectComboBox.setLabel("Multiselect combo box with `clear-button-visible`");
+        multiselectComboBox.setPlaceholder("Add");
+        multiselectComboBox.setItems("Item 1", "Item 2", "Item 3", "Item 4");
+        multiselectComboBox.addSelectionListener(
+                event -> Notification.show(event.toString()));
+
+        multiselectComboBox.setClearButtonVisible(true);
+
+        Button getValueBtn = new Button("Get value");
+        getValueBtn.addClickListener(
+                event -> multiselectComboBoxValueChangeHandler(
+                        multiselectComboBox));
+
+        add(buildDemoContainer(multiselectComboBox, getValueBtn));
+    }
 
     private void multiselectComboBoxValueChangeHandler(MultiselectComboBox<String> multiselectComboBox) {
         Set<String> selectedItems = multiselectComboBox.getValue();


### PR DESCRIPTION
To better align with the vaadin component defaults, the
clear-button-visible attribute is now also available to the
MultiselectComboBox. With this update the component no longer displays
the clear icon by default, but instead it needs to be specified
explicitly. This change breaks the default behavior in favor of aligning
better with the current default behavior of the vaadin-text-field and
vaadin-combo-box components.

ℹ️ This PR backports the same feature that was introduced to the V14 version of this component #19  