### PR TITLE
increased dependency version to include the keep overlay opened feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,23 @@ Integration of of the [multiselect-combo-box](https://github.com/gatanaso/multis
 
 ## Install
 
-Add the `multiselect-combo-box-flow dependency` to your `pom.xml` file:
+Add the `multiselect-combo-box-flow dependency` to your `pom.xml`:
 ```xml
 <dependency>
    <groupId>org.vaadin.gatanaso</groupId>
    <artifactId>multiselect-combo-box-flow</artifactId>
    <version>2.2.1</version>
+</dependency>
+```
+
+To use the latest features of this component, the `vaadin-combo-box-flow` 
+dependency has to be at least `3.0.6` or newer. Therefore, add the following 
+to your pom.xml:
+```xml
+<dependency>
+   <groupId>com.vaadin</groupId>
+   <artifactId>vaadin-combo-box-flow</artifactId>
+   <version>[3.0.6,)</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,6 @@ Add the `multiselect-combo-box-flow dependency` to your `pom.xml`:
 </dependency>
 ```
 
-To use the latest features of this component, the `vaadin-combo-box-flow` 
-dependency has to be at least `3.0.6` or newer. Therefore, add the following 
-to your pom.xml:
-```xml
-<dependency>
-   <groupId>com.vaadin</groupId>
-   <artifactId>vaadin-combo-box-flow</artifactId>
-   <version>[3.0.6,)</version>
-</dependency>
-```
-
 Add the `vaadin-addons` repository:
 ```xml
 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.gatanaso</groupId>
     <artifactId>multiselect-combo-box-flow</artifactId>
-    <version>2.3.0.rc2</version>
+    <version>2.3.0-SNAPSHOT</version>
     <name>Multiselect Combo Box</name>
     <description>Integration of multiselect-combo-box for Vaadin platform</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.gatanaso</groupId>
     <artifactId>multiselect-combo-box-flow</artifactId>
-    <version>2.3.0.rc1</version>
+    <version>2.3.0.rc2</version>
     <name>Multiselect Combo Box</name>
     <description>Integration of multiselect-combo-box for Vaadin platform</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.vaadin.gatanaso</groupId>
     <artifactId>multiselect-combo-box-flow</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0.rc1</version>
     <name>Multiselect Combo Box</name>
     <description>Integration of multiselect-combo-box for Vaadin platform</description>
 

--- a/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
+++ b/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
@@ -81,7 +81,7 @@ import elemental.json.JsonValue;
  * @author gatanaso
  */
 @Tag("multiselect-combo-box")
-@NpmPackage(value = "multiselect-combo-box", version = "2.2.0-alpha.1")
+@NpmPackage(value = "multiselect-combo-box", version = "2.2.0")
 @JsModule("multiselect-combo-box/src/multiselect-combo-box.js")
 @JavaScript("frontend://multiselectComboBoxConnector.js")
 @JsModule("./multiselectComboBoxConnector-es6.js")

--- a/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
+++ b/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
@@ -81,7 +81,7 @@ import elemental.json.JsonValue;
  * @author gatanaso
  */
 @Tag("multiselect-combo-box")
-@NpmPackage(value = "multiselect-combo-box", version = "2.2.0-alpha")
+@NpmPackage(value = "multiselect-combo-box", version = "2.2.0-alpha.1")
 @JsModule("multiselect-combo-box/src/multiselect-combo-box.js")
 @JavaScript("frontend://multiselectComboBoxConnector.js")
 @JsModule("./multiselectComboBoxConnector-es6.js")
@@ -445,6 +445,25 @@ public class MultiselectComboBox<T>
      */
     public void setClearButtonVisible(boolean clearButtonVisible) {
         getElement().setProperty("clearButtonVisible", clearButtonVisible);
+    }
+
+    /**
+     * Gets the value of the configured value separator when in read only mode.
+     *
+     * @return the read only value separator.
+     */
+    public String getReadOnlyValueSeparator() {
+        return getElement().getProperty("readonlyValueSeparator");
+    }
+
+    /**
+     * Sets the value separator when in read only mode.
+     *
+     * @param readonlyValueSeparator
+     *            the separator value to set
+     */
+    public void setReadOnlyValueSeparator(String readonlyValueSeparator) {
+        getElement().setProperty("readonlyValueSeparator", readonlyValueSeparator == null ? "" : readonlyValueSeparator);
     }
 
     private void setItemValuePath(String itemValuePath) {

--- a/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
+++ b/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
@@ -81,7 +81,7 @@ import elemental.json.JsonValue;
  * @author gatanaso
  */
 @Tag("multiselect-combo-box")
-@NpmPackage(value = "multiselect-combo-box", version = "2.1.0")
+@NpmPackage(value = "multiselect-combo-box", version = "2.2.0-alpha")
 @JsModule("multiselect-combo-box/src/multiselect-combo-box.js")
 @JavaScript("frontend://multiselectComboBoxConnector.js")
 @JsModule("./multiselectComboBoxConnector-es6.js")

--- a/src/test/java/org/vaadin/gatanaso/MultiselectComboBoxTest.java
+++ b/src/test/java/org/vaadin/gatanaso/MultiselectComboBoxTest.java
@@ -192,6 +192,7 @@ public class MultiselectComboBoxTest {
     public void shouldSetPageSize() {
         // given
         MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox<>();
+
         assertThat(multiselectComboBox.getPageSize(), is(50)); // default value
 
         // when
@@ -214,6 +215,18 @@ public class MultiselectComboBoxTest {
         // then
         assertThat(multiselectComboBox.isClearButtonVisible(), is(true));
         assertThat(multiselectComboBox.getElement().getProperty("clearButtonVisible"), is("true"));
+    }
+
+    @Test
+    public void shouldSetReadOnlyValueSeparator() {
+        // given
+        MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox<>();
+
+        // when
+        multiselectComboBox.setReadOnlyValueSeparator("***");
+
+        // then
+        assertThat(multiselectComboBox.getReadOnlyValueSeparator(), is("***"));
     }
 
     @Test

--- a/src/test/java/org/vaadin/gatanaso/demo/DemoView.java
+++ b/src/test/java/org/vaadin/gatanaso/demo/DemoView.java
@@ -42,6 +42,7 @@ public class DemoView extends VerticalLayout {
         MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox();
         multiselectComboBox.setLabel("Multiselect combo box with string items");
         multiselectComboBox.setPlaceholder("Add");
+        multiselectComboBox.setWidth("100%");
         multiselectComboBox.setItems("Item 1", "Item 2", "Item 3", "Item 4");
         multiselectComboBox.addSelectionListener(
                 event -> Notification.show(event.toString()));
@@ -58,6 +59,7 @@ public class DemoView extends VerticalLayout {
         MultiselectComboBox<User> multiselectComboBox = new MultiselectComboBox();
         multiselectComboBox.setLabel("Multiselect combo box with object items");
         multiselectComboBox.setPlaceholder("Add");
+        multiselectComboBox.setWidth("100%");
         List<User> data = Arrays.asList(
                 new User("Leanne Graham", "leanne", "leanne@demo.dev"),
                 new User("Ervin Howell", "ervin", "ervin@demo.dev"),
@@ -79,6 +81,7 @@ public class DemoView extends VerticalLayout {
         multiselectComboBox.setLabel(
                 "Multiselect combo box with object items and custom item label generator");
         multiselectComboBox.setPlaceholder("Add");
+        multiselectComboBox.setWidth("100%");
         List<User> data = Arrays.asList(
                 new User("Leanne Graham", "leanne", "leanne@demo.dev"),
                 new User("Ervin Howell", "ervin", "ervin@demo.dev"),
@@ -100,6 +103,7 @@ public class DemoView extends VerticalLayout {
         MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox();
         multiselectComboBox.setLabel("Required multiselect combo box");
         multiselectComboBox.setPlaceholder("Add");
+        multiselectComboBox.setWidth("100%");
         multiselectComboBox.setRequired(true);
         multiselectComboBox.setErrorMessage("The field is mandatory");
         multiselectComboBox.setItems("Item 1", "Item 2", "Item 3", "Item 4");
@@ -118,6 +122,7 @@ public class DemoView extends VerticalLayout {
         MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox();
         multiselectComboBox.setLabel("Multiselect combo box in compact mode");
         multiselectComboBox.setPlaceholder("Add");
+        multiselectComboBox.setWidth("100%");
         multiselectComboBox.setItems("Item 1", "Item 2", "Item 3", "Item 4");
         multiselectComboBox.addSelectionListener(
                 event -> Notification.show(event.toString()));
@@ -137,6 +142,7 @@ public class DemoView extends VerticalLayout {
         multiselectComboBox.setLabel(
                 "Multiselect combo box with ordered selected items list");
         multiselectComboBox.setPlaceholder("Add");
+        multiselectComboBox.setWidth("100%");
         multiselectComboBox.setItems("Item 1", "Item 2", "Item 3", "Item 4");
         multiselectComboBox.addSelectionListener(
                 event -> Notification.show(event.toString()));
@@ -155,6 +161,7 @@ public class DemoView extends VerticalLayout {
         MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox();
         multiselectComboBox.setLabel("Multiselect with lazy loading");
         multiselectComboBox.setPlaceholder("Add");
+        multiselectComboBox.setWidth("100%");
 
         List<String> items =IntStream.range(1, 10000).mapToObj(num -> "Item " + num).collect(Collectors.toList());
         multiselectComboBox.setItems(items);
@@ -174,6 +181,7 @@ public class DemoView extends VerticalLayout {
         MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox();
         multiselectComboBox.setLabel("Multiselect combo box with `clear-button-visible`");
         multiselectComboBox.setPlaceholder("Add");
+        multiselectComboBox.setWidth("100%");
         multiselectComboBox.setItems("Item 1", "Item 2", "Item 3", "Item 4");
         multiselectComboBox.addSelectionListener(
                 event -> Notification.show(event.toString()));


### PR DESCRIPTION
This PR adds the latest dependency of the `multiselect-combo-box` and with that introduces the much needed feature of keeping the overlay opened when selecting items. Furthermore, it also removes the default full width and adds the api for working with the newly added `readonlyValueSeparator` property.
fixes #26 
fixes #27 