### PR TITLE
fix issue with filtering losing values

### DIFF
--- a/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
+++ b/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.data.provider.ArrayUpdater;
 import com.vaadin.flow.data.provider.CallbackDataProvider;
 import com.vaadin.flow.data.provider.CompositeDataGenerator;
 import com.vaadin.flow.data.provider.DataChangeEvent;
-import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataKeyMapper;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.ListDataProvider;
@@ -81,7 +80,7 @@ import elemental.json.JsonValue;
  * @author gatanaso
  */
 @Tag("multiselect-combo-box")
-@NpmPackage(value = "multiselect-combo-box", version = "2.2.0")
+@NpmPackage(value = "multiselect-combo-box", version = "2.3.1")
 @JsModule("multiselect-combo-box/src/multiselect-combo-box.js")
 @JavaScript("frontend://multiselectComboBoxConnector.js")
 @JsModule("./multiselectComboBoxConnector-es6.js")
@@ -111,7 +110,7 @@ public class MultiselectComboBox<T>
         }
     };
 
-    private DataCommunicator<T> dataCommunicator;
+    private MultiselectComboBoxDataCommunicator<T> dataCommunicator;
     private ItemLabelGenerator<T> itemLabelGenerator = String::valueOf;
 
     private SerializableConsumer<String> filterSlot = filter -> {
@@ -217,9 +216,13 @@ public class MultiselectComboBox<T>
             MultiselectComboBox<T> multiselectComboBox,
             JsonArray presentation) {
 
-        if (presentation == null
-                || multiselectComboBox.dataCommunicator == null) {
+        if (presentation == null || multiselectComboBox.dataCommunicator == null) {
             return multiselectComboBox.getEmptyValue();
+        }
+
+        if (multiselectComboBox.getValue() != null) {
+            // keep existing value items in keyMapper
+            multiselectComboBox.getValue().forEach(item -> multiselectComboBox.getKeyMapper().key(item));
         }
 
         Set<T> set = new HashSet<>();
@@ -779,7 +782,7 @@ public class MultiselectComboBox<T>
         }
 
         if (dataCommunicator == null) {
-            dataCommunicator = new DataCommunicator<>(dataGenerator,
+            dataCommunicator = new MultiselectComboBoxDataCommunicator<>(dataGenerator,
                     arrayUpdater, data -> getElement()
                             .callJsFunction("$connector.updateData", data),
                     getElement().getNode());

--- a/src/main/java/org/vaadin/gatanaso/MultiselectComboBoxDataCommunicator.java
+++ b/src/main/java/org/vaadin/gatanaso/MultiselectComboBoxDataCommunicator.java
@@ -1,0 +1,57 @@
+package org.vaadin.gatanaso;
+
+import com.vaadin.flow.data.provider.ArrayUpdater;
+import com.vaadin.flow.data.provider.DataCommunicator;
+import com.vaadin.flow.data.provider.DataGenerator;
+import com.vaadin.flow.data.provider.KeyMapper;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.internal.StateNode;
+
+import elemental.json.JsonArray;
+
+/**
+ * Data communicator that handles requesting data and sending it to client side.
+ *
+ * @param <T> the bean type
+ */
+public class MultiselectComboBoxDataCommunicator<T> extends DataCommunicator<T> {
+
+	private KeyMapper<T> uniqueKeyMapper = new KeyMapper<T>() {
+
+		private T object;
+
+		@Override
+		public String key(T o) {
+			this.object = o;
+			try {
+				return super.key(o);
+			} finally {
+				this.object = null;
+			}
+		}
+
+		@Override
+		protected String createKey() {
+			return String.valueOf(object.hashCode());
+		}
+	};
+
+	/**
+	 * Creates a new instance.
+	 *
+	 * @param dataGenerator
+	 *            the data generator function
+	 * @param arrayUpdater
+	 *            array updater strategy
+	 * @param dataUpdater
+	 *            data updater strategy
+	 * @param stateNode
+	 *            the state node used to communicate for
+	 */
+	public MultiselectComboBoxDataCommunicator(DataGenerator<T> dataGenerator, ArrayUpdater arrayUpdater, SerializableConsumer<JsonArray> dataUpdater,
+			StateNode stateNode) {
+
+		super(dataGenerator, arrayUpdater, dataUpdater, stateNode);
+		setKeyMapper(uniqueKeyMapper);
+	}
+}


### PR DESCRIPTION
- Introduced a custom data communicator which uses the hash code
of the underlying object to generate it's key.
- Updated the presentation to model function to regenerate the
keys for the current value, prior to setting the presentation value
to the model value in order to avoid lost values due to filtering
- Updated web component dependency version to 2.3.1

fixes #30 and #36