### PR TITLE
feature/allow custom values

### DIFF
--- a/src/test/java/org/vaadin/gatanaso/MultiselectComboBoxTest.java
+++ b/src/test/java/org/vaadin/gatanaso/MultiselectComboBoxTest.java
@@ -230,6 +230,21 @@ public class MultiselectComboBoxTest {
     }
 
     @Test
+    public void shouldSetAllowCustomValues() {
+        // given
+        MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox<>();
+
+        Assert.assertFalse(multiselectComboBox.isAllowCustomValues());
+
+        // when
+        multiselectComboBox.setAllowCustomValues(true);
+
+        // then
+        assertThat(multiselectComboBox.isAllowCustomValues(), is(true));
+        assertThat(multiselectComboBox.getElement().getProperty("allowCustomValues"), is("true"));
+    }
+
+    @Test
     public void shouldUpdateDataProviderAndResetValueToEmpty() {
         // given
         MultiselectComboBox<Object> multiselectComboBox = new MultiselectComboBox<>();

--- a/src/test/java/org/vaadin/gatanaso/demo/DemoView.java
+++ b/src/test/java/org/vaadin/gatanaso/demo/DemoView.java
@@ -12,6 +12,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.router.Route;
 
 @Route("")
@@ -30,6 +31,7 @@ public class DemoView extends VerticalLayout {
         addOrderedDemo();
         addLazyLoadingDemo();
         addClearButtonVisibleDemo();
+        addAllowCustomValuesDemo();
     }
 
     private void addTitle() {
@@ -192,6 +194,31 @@ public class DemoView extends VerticalLayout {
         getValueBtn.addClickListener(
                 event -> multiselectComboBoxValueChangeHandler(
                         multiselectComboBox));
+
+        add(buildDemoContainer(multiselectComboBox, getValueBtn));
+    }
+
+    private void addAllowCustomValuesDemo() {
+        MultiselectComboBox<String> multiselectComboBox = new MultiselectComboBox();
+        multiselectComboBox.setLabel("Allow custom values");
+        multiselectComboBox.setPlaceholder("Select existing or input custom value");
+        multiselectComboBox.setWidth("100%");
+        List<String> items = Arrays.asList("Java", "Go", "Python", "C#");
+        multiselectComboBox.setItems(items);
+
+        multiselectComboBox.addCustomValuesSetListener(e -> {
+            Set<String> existingSelected = multiselectComboBox.getValue().stream().collect(Collectors.toSet());
+            existingSelected.add(e.getDetail());
+            List<String> updatedItems = multiselectComboBox.getDataProvider().fetch(new Query<>()).collect(Collectors.toList());
+            updatedItems.add(e.getDetail());
+            multiselectComboBox.setItems(updatedItems);
+            multiselectComboBox.setValue(existingSelected);
+        });
+
+        Button getValueBtn = new Button("Get value");
+        getValueBtn.addClickListener(
+            event -> multiselectComboBoxValueChangeHandler(
+                multiselectComboBox));
 
         add(buildDemoContainer(multiselectComboBox, getValueBtn));
     }


### PR DESCRIPTION
This PR allows adding custom values to the `MultiselectComboBox`(fixes #23).

If the `allowCustomValues` flag is set the `MultiselectComboBox` will accept input values and fire a `custom-values-set` event. It is the responsibility of the user to decide what to do with that value as it is not automatically added to the list of items or existing values.