### PR TITLE
modified the way the component is initialized

### DIFF
--- a/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
+++ b/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
@@ -83,7 +83,7 @@ import elemental.json.JsonValue;
  * @author gatanaso
  */
 @Tag("multiselect-combo-box")
-@NpmPackage(value = "multiselect-combo-box", version = "2.4.1")
+@NpmPackage(value = "multiselect-combo-box", version = "2.4.2")
 @JsModule("multiselect-combo-box/src/multiselect-combo-box.js")
 @JsModule("./multiselectComboBoxConnector.js")
 public class MultiselectComboBox<T>
@@ -725,6 +725,12 @@ public class MultiselectComboBox<T>
     @ClientCallable
     private void resetDataCommunicator() {
         dataCommunicator.reset();
+    }
+
+    @ClientCallable
+    private void initDataConnector() {
+        // init data connector when shadow-dom is ready
+        getElement().executeJs("$0.$connector.initDataConnector()");
     }
 
     /**

--- a/src/main/resources/META-INF/resources/frontend/multiselectComboBoxConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/multiselectComboBoxConnector.js
@@ -16,7 +16,7 @@ window.Vaadin.Flow.multiselectComboBoxConnector = {
     let cache = {};
     let lastFilter = '';
 
-    customElements.whenDefined('multiselect-combo-box').then(() => {
+    multiselectComboBox.$connector.initDataConnector = function() {
       multiselectComboBox.$.comboBox.dataProvider = function (params, callback) {
         if (params.pageSize != multiselectComboBox.$.comboBox.pageSize
             && multiselectComboBox.pageSize != multiselectComboBox.$.comboBox.pageSize) {
@@ -75,7 +75,7 @@ window.Vaadin.Flow.multiselectComboBoxConnector = {
           pageCallbacks[params.page] = callback;
         }
       };
-    });
+    };
 
     multiselectComboBox.$connector.filter = function (item, filter) {
       filter = filter ? filter.toString().toLowerCase() : '';


### PR DESCRIPTION
In order to handle the case when the component is used in a dialog,
updated the connector to initialize the data provider only after
the shadow-dow has been fully initialized on the client side.

This is a port of the same PR fix (#51) but for Vaadin 15.