### PR TITLE
introduced capability to set custom unique key data generator

### DIFF
--- a/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
+++ b/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
@@ -263,7 +263,7 @@ public class MultiselectComboBox<T>
     @Override
     public void setValue(Set<T> value) {
         if (dataCommunicator == null) {
-            if (value == null) {
+            if (value == null || value.equals(getEmptyValue())) {
                 return;
             } else {
                 throw new IllegalStateException(

--- a/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
+++ b/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
@@ -117,6 +117,7 @@ public class MultiselectComboBox<T>
     };
 
     private MultiselectComboBoxDataCommunicator<T> dataCommunicator;
+    private Function<T, Object> uniqueKeyDataGenerator;
     private ItemLabelGenerator<T> itemLabelGenerator = String::valueOf;
     private Registration dataGeneratorRegistration;
 
@@ -928,6 +929,9 @@ public class MultiselectComboBox<T>
                     arrayUpdater, data -> getElement()
                             .callJsFunction("$connector.updateData", data),
                     getElement().getNode());
+            if (uniqueKeyDataGenerator != null) {
+            	dataCommunicator.setUniqueKeyDataGenerator(uniqueKeyDataGenerator);
+            }
         }
 
         scheduleRender();
@@ -1125,6 +1129,7 @@ public class MultiselectComboBox<T>
      * @param uniqueKeyDataGenerator {@link Function} to generate unique key data
      */
     public void setUniqueKeyDataGenerator(Function<T, Object> uniqueKeyDataGenerator) {
+       this.uniqueKeyDataGenerator = uniqueKeyDataGenerator;
        if (dataCommunicator != null) {
       	 dataCommunicator.setUniqueKeyDataGenerator(uniqueKeyDataGenerator);
        }

--- a/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
+++ b/src/main/java/org/vaadin/gatanaso/MultiselectComboBox.java
@@ -1119,6 +1119,18 @@ public class MultiselectComboBox<T>
     }
 
     /**
+     * Sets the given {@link Function} as unique key data generator.
+     * The default implementation is {@link Object#hashCode()}.
+     *
+     * @param uniqueKeyDataGenerator {@link Function} to generate unique key data
+     */
+    public void setUniqueKeyDataGenerator(Function<T, Object> uniqueKeyDataGenerator) {
+       if (dataCommunicator != null) {
+      	 dataCommunicator.setUniqueKeyDataGenerator(uniqueKeyDataGenerator);
+       }
+    }
+
+    /**
      * Predicate to check {@link MultiselectComboBox} items against user typed
      * strings.
      */

--- a/src/main/java/org/vaadin/gatanaso/MultiselectComboBoxDataCommunicator.java
+++ b/src/main/java/org/vaadin/gatanaso/MultiselectComboBoxDataCommunicator.java
@@ -1,5 +1,7 @@
 package org.vaadin.gatanaso;
 
+import java.util.function.Function;
+
 import com.vaadin.flow.data.provider.ArrayUpdater;
 import com.vaadin.flow.data.provider.DataCommunicator;
 import com.vaadin.flow.data.provider.DataGenerator;
@@ -15,6 +17,8 @@ import elemental.json.JsonArray;
  * @param <T> the bean type
  */
 public class MultiselectComboBoxDataCommunicator<T> extends DataCommunicator<T> {
+
+	private Function<T, Object> uniqueKeyDataGenerator = Object::hashCode;
 
 	private KeyMapper<T> uniqueKeyMapper = new KeyMapper<T>() {
 
@@ -32,7 +36,7 @@ public class MultiselectComboBoxDataCommunicator<T> extends DataCommunicator<T> 
 
 		@Override
 		protected String createKey() {
-			return String.valueOf(object.hashCode());
+			return String.valueOf(uniqueKeyDataGenerator.apply(object));
 		}
 	};
 
@@ -53,5 +57,15 @@ public class MultiselectComboBoxDataCommunicator<T> extends DataCommunicator<T> 
 
 		super(dataGenerator, arrayUpdater, dataUpdater, stateNode);
 		setKeyMapper(uniqueKeyMapper);
+	}
+
+	/**
+	 * Sets the given {@link Function} as unique key data generator.
+	 * The default implementation is {@link Object#hashCode()}.
+	 *
+	 * @param uniqueKeyDataGenerator {@link Function} to generate unique key data
+	 */
+	public void setUniqueKeyDataGenerator(Function<T, Object> uniqueKeyDataGenerator) {
+		this.uniqueKeyDataGenerator = uniqueKeyDataGenerator;
 	}
 }


### PR DESCRIPTION
Added the setUniqueKeyDataGenerator() method which allows setting custom unique key data generator for the DataCommunicator which is responsible for generating a unique key for every possible choice of the MultiselectComboBox.

This ability is required because in some cases the hashCode is not unique (for example: JPA entities [according to this](https://vladmihalcea.com/how-to-implement-equals-and-hashcode-using-the-jpa-entity-identifier)).